### PR TITLE
Check replies instead of storing replied-to comments

### DIFF
--- a/nbviewerbot/nbviewerbot.py
+++ b/nbviewerbot/nbviewerbot.py
@@ -96,7 +96,7 @@ def already_replied(praw_obj, username):
         replies = praw_obj.comments
 
     for r in replies:
-        if r.author.name.lower == username.lower:
+        if r.author.name.lower() == username.lower:
             return True
 
     return False

--- a/nbviewerbot/nbviewerbot.py
+++ b/nbviewerbot/nbviewerbot.py
@@ -131,7 +131,7 @@ def process_praw_object(praw_obj, username):
             post_reply(praw_obj, reply_text)
         except prawcore.exceptions.Forbidden:
             # Ddon't crash if we get banned from a sub
-            resources.REPLY_DICT[obj_id] = "FORBIDDEN"
+            return
 
 
 def main(subreddits):
@@ -157,7 +157,6 @@ def main(subreddits):
 
     # save the reply dict when the script exits
     atexit.register(lambda: logger.info("Exited nbviewerbot"))
-    atexit.register(utils.pickle_reply_dict)
 
     # create workers to add praw objects to the queue
     workers = []

--- a/nbviewerbot/nbviewerbot.py
+++ b/nbviewerbot/nbviewerbot.py
@@ -90,6 +90,7 @@ def already_replied(praw_obj, username):
     replies = []
 
     if isinstance(praw_obj, praw.models.Comment):
+        praw_obj.refresh()  # https://github.com/praw-dev/praw/issues/413
         replies = praw_obj.replies
     elif isinstance(praw_obj, praw.models.Submission):
         replies = praw_obj.comments
@@ -112,7 +113,7 @@ def process_praw_object(praw_obj, username):
 
     # don't reply to comments more than once
     if already_replied(praw_obj, username):
-        logger.debug("Skipping {} {}, already replied".format(obj_type, obj_id))
+        logger.info("Skipping {} {}, already replied".format(obj_type, obj_id))
         return
 
     jupy_links = []

--- a/nbviewerbot/nbviewerbot.py
+++ b/nbviewerbot/nbviewerbot.py
@@ -87,16 +87,16 @@ def already_replied(praw_obj, username):
     bool
 
     """
-    replies = []
-
     if isinstance(praw_obj, praw.models.Comment):
         praw_obj.refresh()  # https://github.com/praw-dev/praw/issues/413
         replies = praw_obj.replies
     elif isinstance(praw_obj, praw.models.Submission):
         replies = praw_obj.comments
+    else:
+        raise TypeError("praw_obj should be a Comment or Submission")
 
     for r in replies:
-        if r.author.name.lower() == username.lower:
+        if r.author.name.lower() == username.lower():
             return True
 
     return False

--- a/nbviewerbot/nbviewerbot.py
+++ b/nbviewerbot/nbviewerbot.py
@@ -51,6 +51,7 @@ def get_streams(subreddits):
             x["args"][0].id, str(x)
         )
     ),
+    giveup=lambda e: isinstance(e, prawcore.exceptions.Forbidden),
     on_giveup=lambda x: resources.LOGGER.exception(
         "Max retries reached, giving up on comment {}. Details: {}".format(
             x["args"][0].id, str(x)

--- a/nbviewerbot/nbviewerbot.py
+++ b/nbviewerbot/nbviewerbot.py
@@ -96,6 +96,10 @@ def already_replied(praw_obj, username):
         raise TypeError("praw_obj should be a Comment or Submission")
 
     for r in replies:
+        if r.author is None:
+            # Probably deleted account
+            continue
+
         if r.author.name.lower() == username.lower():
             return True
 

--- a/nbviewerbot/resources.py
+++ b/nbviewerbot/resources.py
@@ -68,7 +68,9 @@ def load_reddit():
     kwargs = get_reddit_auth_kwargs()
     reddit = praw.Reddit(**kwargs)
     LOGGER.info(
-        f"Successfully authenticated with Reddit as {reddit.user.me().name}"
+        "Successfully authenticated with Reddit as {}".format(
+            reddit.user.me().name
+        )
     )
     return reddit
 

--- a/nbviewerbot/resources.py
+++ b/nbviewerbot/resources.py
@@ -131,14 +131,6 @@ links to start your own Jupyter server!
 _url_rx = "^http.*"
 URL_RX = re.compile(_url_rx)
 
-# Activity tracking
-REPLY_DICT_PATH = os.path.join(SRC_DIR, "reply_dict.pkl")
-try:
-    with open(REPLY_DICT_PATH, "rb") as h:
-        REPLY_DICT = pickle.load(h)
-except FileNotFoundError:
-    REPLY_DICT = {}
-
 # Subreddit lists
 SUBREDDITS_TEST = [
     "testingground4bots",

--- a/nbviewerbot/resources.py
+++ b/nbviewerbot/resources.py
@@ -67,7 +67,9 @@ def load_reddit():
     """
     kwargs = get_reddit_auth_kwargs()
     reddit = praw.Reddit(**kwargs)
-    LOGGER.info("Successfully authenticated with Reddit")
+    LOGGER.info(
+        f"Successfully authenticated with Reddit as {reddit.user.mer().name}"
+    )
     return reddit
 
 

--- a/nbviewerbot/resources.py
+++ b/nbviewerbot/resources.py
@@ -68,7 +68,7 @@ def load_reddit():
     kwargs = get_reddit_auth_kwargs()
     reddit = praw.Reddit(**kwargs)
     LOGGER.info(
-        f"Successfully authenticated with Reddit as {reddit.user.mer().name}"
+        f"Successfully authenticated with Reddit as {reddit.user.me().name}"
     )
     return reddit
 

--- a/nbviewerbot/utils.py
+++ b/nbviewerbot/utils.py
@@ -197,15 +197,6 @@ def setup_logger(console_level=logging.INFO, file_level=logging.DEBUG):
     return logger
 
 
-def pickle_reply_dict():
-    """
-    Pickle resources.REPLY_DICT to resources.REPLY_DICT_PATH.
-    """
-    resources.LOGGER.info("Saving reply log...")
-    with open(resources.REPLY_DICT_PATH, "wb") as h:
-        pickle.dump(resources.REPLY_DICT, h)
-
-
 def praw_object_type(praw_obj):
     """Return the type of the praw object (comment/submission) as a
     lowercase string."""

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -42,7 +42,3 @@ class TestSubredditsRelevant:
 
     def test_no_empty_strings(self):
         assert "" not in resources.SUBREDDITS_RELEVANT
-
-
-def test_reply_dict():
-    assert type(resources.REPLY_DICT) is dict


### PR DESCRIPTION
The `REPLY_DICT` was just going to grow infinitely. Having a db or something not in memory would have been a workaround, but a friendly Redditor pointed out that just parsing the existing replies to a comment/submission and looking for our own username was a better way to do it. 

This is slightly slower so also added some logic to handle the queues filling up (still shouldn't happen since the bot posts like 2 comments per week)